### PR TITLE
Update Paranamer to version 2.8 to support lambdas in intercepted met…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
         <dependency>
             <groupId>com.thoughtworks.paranamer</groupId>
             <artifactId>paranamer</artifactId>
-            <version>2.6</version>
+            <version>2.8</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
…hod-parameters

The Paranamer produced ArrayIndexOutOfBoundsException when cdi-interceptor encounters methods containing Lambda-Expressions
I tested this by excluding Paranamer 2.6 in our maven dependencies and using Paranamer 2.8 instead.

See
https://github.com/orika-mapper/orika/issues/60


Greatings
Andreas 